### PR TITLE
禁用 broadcastingPane 和 hintPane2

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/HiPerMultiplayerPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/HiPerMultiplayerPageSkin.java
@@ -297,9 +297,9 @@ public class HiPerMultiplayerPageSkin extends DecoratorAnimatedPage.DecoratorAni
 
                         FXUtils.onChangeAndOperate(control.broadcasterProperty(), broadcaster -> {
                             if (broadcaster == null) {
-                                slavePane.getChildren().setAll(titlePane, hintPane, hintPane2, notBroadcastingPane);
+                                slavePane.getChildren().setAll(titlePane, hintPane);
                             } else {
-                                slavePane.getChildren().setAll(titlePane, hintPane, hintPane2, broadcastingPane);
+                                slavePane.getChildren().setAll(titlePane, hintPane);
                             }
                         });
                     }


### PR DESCRIPTION
因为这俩东西很容易误导

broadcastingPane 的替代品就是在启动多人联机时 U1 离线账户启动游戏会使用 authlib-injector ，就可以绕过正版认证